### PR TITLE
Use chainid and remove static networks

### DIFF
--- a/actions/action_monitor_transfers.go
+++ b/actions/action_monitor_transfers.go
@@ -22,6 +22,24 @@ var (
 	monitoredAddresses = mapset.NewSet[common.Address]()
 )
 
+// tryExtracting attempts to extract and type-assert a value from a map.
+// Returns the value and an error if the key doesn't exist or type assertion fails.
+func tryExtracting[T any](
+	source map[string]interface{},
+	valueName string,
+) (T, error) {
+	var value T
+	valueInterface, ok := source[valueName]
+	if !ok || valueInterface == nil {
+		return value, fmt.Errorf("missing value for %s", valueName)
+	}
+	value, ok = valueInterface.(T)
+	if !ok {
+		return value, fmt.Errorf("invalid type for %s", valueName)
+	}
+	return value, nil
+}
+
 // addressMatchesWalletTopics returns true if the given address matches any of
 // the wallet-topic filters (used when server-side topic filtering is enabled).
 func addressMatchesWalletTopics(addr common.Address) bool {
@@ -155,33 +173,19 @@ func handleAddressTx(tx ActionTxData) {
 
 // called when erc20 token we're tracking emits Transfer event
 func handleTokenTransfer(event ActionEventData) {
-	// Defensive guards: fields may be missing or of unexpected types; skip if so
-	valueInterface, ok := event.DecodedData["value"]
-	if !ok || valueInterface == nil {
-		return
-	}
-	value, ok := valueInterface.(*big.Int)
-	if !ok || value == nil {
-		return
-	}
-	if value.Cmp(big.NewInt(0)) == 0 {
+	// Extract and validate event fields
+	value, err := tryExtracting[*big.Int](event.DecodedData, "value")
+	if err != nil || value == nil || value.Cmp(big.NewInt(0)) == 0 {
 		return
 	}
 
-	fromInterface, ok := event.DecodedTopics["from"]
-	if !ok || fromInterface == nil {
+	from, err := tryExtracting[common.Address](event.DecodedTopics, "from")
+	if err != nil {
 		return
 	}
-	toInterface, ok := event.DecodedTopics["to"]
-	if !ok || toInterface == nil {
-		return
-	}
-	from, ok := fromInterface.(common.Address)
-	if !ok {
-		return
-	}
-	to, ok := toInterface.(common.Address)
-	if !ok {
+
+	to, err := tryExtracting[common.Address](event.DecodedTopics, "to")
+	if err != nil {
 		return
 	}
 

--- a/actions/action_monitor_transfers.go
+++ b/actions/action_monitor_transfers.go
@@ -25,6 +25,9 @@ var (
 // addressMatchesWalletTopics returns true if the given address matches any of
 // the wallet-topic filters (used when server-side topic filtering is enabled).
 func addressMatchesWalletTopics(addr common.Address) bool {
+	shared.FilterWalletTopicsMutex.RLock()
+	defer shared.FilterWalletTopicsMutex.RUnlock()
+
 	if len(shared.FilterWalletTopics) == 0 {
 		return false
 	}
@@ -44,8 +47,10 @@ func AddAddressToMonitoredAddresses(address common.Address) error {
 	// Notify the event listener to create wallet-topic ERC20 Transfer
 	// subscriptions for this new address (server-side filtering) and update
 	// filters immediately for blocks/historical.
+	shared.FilterWalletTopicsMutex.Lock()
 	shared.FilterWalletTopics = append(shared.FilterWalletTopics, common.BytesToHash(address.Bytes()))
-	shared.NewWalletTopicChan <- address
+	shared.FilterWalletTopicsMutex.Unlock()
+
 	// Always print to console when a wallet address is added/updated
 	fmt.Printf("Monitored wallet address added: %s\n", address.Hex())
 	return nil
@@ -54,21 +59,12 @@ func AddAddressToMonitoredAddresses(address common.Address) error {
 func (p action) InitMonitorTransfers() {
 	// Always enable wallet-topic ERC20 Transfer filtering (from/to)
 	shared.UseDualTransferWalletFilters = true
-	// monitor addresses for transactions
-	for _, address := range p.o.Addresses {
-		AddAddressToMonitoredAddresses(address)
-	}
 
-	// Build wallet-topic filters from configured addresses
-	var walletTopics []common.Hash
-	for _, addr := range p.o.Addresses {
-		walletTopics = append(walletTopics, common.BytesToHash(addr.Bytes()))
-	}
-	shared.FilterWalletTopics = walletTopics
+	// Addresses are dynamically added via NATS using AddAddressToMonitoredAddresses()
+	// No need to read from config "addresses": {} field
 
 	// Monitor all ERC20 Transfer events globally; filter by monitored addresses in handler
 	addEventSigAction(eventSignatureTransfer, handleTokenTransfer)
-
 }
 
 // called when a tx is from/to monitored address

--- a/actions/action_monitor_transfers.go
+++ b/actions/action_monitor_transfers.go
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"math/big"
 	"time"
@@ -45,6 +46,8 @@ func AddAddressToMonitoredAddresses(address common.Address) error {
 	// filters immediately for blocks/historical.
 	shared.FilterWalletTopics = append(shared.FilterWalletTopics, common.BytesToHash(address.Bytes()))
 	shared.NewWalletTopicChan <- address
+	// Always print to console when a wallet address is added/updated
+	fmt.Printf("Monitored wallet address added: %s\n", address.Hex())
 	return nil
 }
 

--- a/actions/action_monitor_transfers.go
+++ b/actions/action_monitor_transfers.go
@@ -21,38 +21,51 @@ var (
 	monitoredAddresses = mapset.NewSet[common.Address]()
 )
 
+// addressMatchesWalletTopics returns true if the given address matches any of
+// the wallet-topic filters (used when server-side topic filtering is enabled).
+func addressMatchesWalletTopics(addr common.Address) bool {
+	if len(shared.FilterWalletTopics) == 0 {
+		return false
+	}
+	hashed := common.BytesToHash(addr.Bytes())
+	for _, h := range shared.FilterWalletTopics {
+		if h == hashed {
+			return true
+		}
+	}
+	return false
+}
+
 func AddAddressToMonitoredAddresses(address common.Address) error {
 	addTxAddressAction(address, handleAddressTx)
 	monitoredAddresses.Add(address)
-	return nil
-}
 
-func AddContractAddressToMonitoredAddresses(contractAddress common.Address) error {
-	addAddressEventSigAction(
-		contractAddress,
-		eventSignatureTransfer,
-		handleTokenTransfer,
-	)
-	monitoredAddresses.Add(contractAddress)
+	// Notify the event listener to create wallet-topic ERC20 Transfer
+	// subscriptions for this new address (server-side filtering) and update
+	// filters immediately for blocks/historical.
+	shared.FilterWalletTopics = append(shared.FilterWalletTopics, common.BytesToHash(address.Bytes()))
+	shared.NewWalletTopicChan <- address
 	return nil
 }
 
 func (p action) InitMonitorTransfers() {
+	// Always enable wallet-topic ERC20 Transfer filtering (from/to)
+	shared.UseDualTransferWalletFilters = true
 	// monitor addresses for transactions
 	for _, address := range p.o.Addresses {
 		AddAddressToMonitoredAddresses(address)
 	}
 
-	// monitor erc20 token for transfer events
-	erc20TokenAddresses := p.o.CustomOptions["erc20-tokens"].([]any)
-	for _, erc20TokenAddress := range erc20TokenAddresses {
-		var (
-			erc20TokenAddressString = erc20TokenAddress.(string)
-			typedERC20TokenAddress  = common.HexToAddress(erc20TokenAddressString)
-		)
-
-		AddContractAddressToMonitoredAddresses(typedERC20TokenAddress)
+	// Build wallet-topic filters from configured addresses
+	var walletTopics []common.Hash
+	for _, addr := range p.o.Addresses {
+		walletTopics = append(walletTopics, common.BytesToHash(addr.Bytes()))
 	}
+	shared.FilterWalletTopics = walletTopics
+
+	// Monitor all ERC20 Transfer events globally; filter by monitored addresses in handler
+	addEventSigAction(eventSignatureTransfer, handleTokenTransfer)
+
 }
 
 // called when a tx is from/to monitored address
@@ -143,20 +156,52 @@ func handleAddressTx(tx ActionTxData) {
 
 // called when erc20 token we're tracking emits Transfer event
 func handleTokenTransfer(event ActionEventData) {
-	value := event.DecodedData["value"].(*big.Int)
+	// Defensive guards: fields may be missing or of unexpected types; skip if so
+	valueInterface, ok := event.DecodedData["value"]
+	if !ok || valueInterface == nil {
+		return
+	}
+	value, ok := valueInterface.(*big.Int)
+	if !ok || value == nil {
+		return
+	}
 	if value.Cmp(big.NewInt(0)) == 0 {
 		return
 	}
 
+	fromInterface, ok := event.DecodedTopics["from"]
+	if !ok || fromInterface == nil {
+		return
+	}
+	toInterface, ok := event.DecodedTopics["to"]
+	if !ok || toInterface == nil {
+		return
+	}
+	from, ok := fromInterface.(common.Address)
+	if !ok {
+		return
+	}
+	to, ok := toInterface.(common.Address)
+	if !ok {
+		return
+	}
+
 	var (
-		from            = event.DecodedTopics["from"].(common.Address)
-		to              = event.DecodedTopics["to"].(common.Address)
 		isFromMonitored = monitoredAddresses.Contains(from)
 		isToMonitored   = monitoredAddresses.Contains(to)
 	)
 
-	if !isFromMonitored && !isToMonitored {
-		return
+	// When using server-side wallet topic filtering, also treat matches to the
+	// configured wallet topics as monitored (even if monitoredAddresses hasn't
+	// been populated yet by NATS/config at this moment in time).
+	if shared.UseDualTransferWalletFilters {
+		if !(isFromMonitored || isToMonitored || addressMatchesWalletTopics(from) || addressMatchesWalletTopics(to)) {
+			return
+		}
+	} else {
+		if !isFromMonitored && !isToMonitored {
+			return
+		}
 	}
 
 	var (

--- a/actions/action_monitor_transfers.go
+++ b/actions/action_monitor_transfers.go
@@ -43,19 +43,8 @@ func tryExtracting[T any](
 // addressMatchesWalletTopics returns true if the given address matches any of
 // the wallet-topic filters (used when server-side topic filtering is enabled).
 func addressMatchesWalletTopics(addr common.Address) bool {
-	shared.FilterWalletTopicsMutex.RLock()
-	defer shared.FilterWalletTopicsMutex.RUnlock()
-
-	if len(shared.FilterWalletTopics) == 0 {
-		return false
-	}
 	hashed := common.BytesToHash(addr.Bytes())
-	for _, h := range shared.FilterWalletTopics {
-		if h == hashed {
-			return true
-		}
-	}
-	return false
+	return shared.MonitoredAddressHashes().Contains(hashed)
 }
 
 func AddAddressToMonitoredAddresses(address common.Address) error {
@@ -65,9 +54,7 @@ func AddAddressToMonitoredAddresses(address common.Address) error {
 	// Notify the event listener to create wallet-topic ERC20 Transfer
 	// subscriptions for this new address (server-side filtering) and update
 	// filters immediately for blocks/historical.
-	shared.FilterWalletTopicsMutex.Lock()
-	shared.FilterWalletTopics = append(shared.FilterWalletTopics, common.BytesToHash(address.Bytes()))
-	shared.FilterWalletTopicsMutex.Unlock()
+	shared.MonitoredAddressHashes().Add(common.BytesToHash(address.Bytes()))
 
 	// Always print to console when a wallet address is added/updated
 	fmt.Printf("Monitored wallet address added: %s\n", address.Hex())

--- a/actions/events.go
+++ b/actions/events.go
@@ -20,15 +20,6 @@ const (
 	StatusSuccess           = "success"
 )
 
-var networkMap = map[string]string{
-	"1":        "mainnet",
-	"5":        "goerli",
-	"2026":     "lower-qa",
-	"2025":     "higher-prod",
-	"17069":    "holesky",
-	"11155111": "sepolia",
-}
-
 func (txData *ActionTxData) ToDestinationBalance(balance *big.Int) webhook.WebhookMessageUnifiedConfirmedBalanceRequest {
 	return txData.toBalance(txData.To, balance)
 }
@@ -93,8 +84,8 @@ func (txData *ActionTxData) ToTransaction() webhook.WebhookMessageUnifiedConfirm
 			TxId:        txHash,
 		},
 		EventType: EventTypeTransaction,
-		Network:   networkName(shared.ChainID),
-		Protocol:  ProtocolEthereum,
+		Network:   "",
+		Protocol:  "",
 	}
 }
 
@@ -112,8 +103,8 @@ func (txData *ActionTxData) toBalance(address *common.Address, balance *big.Int)
 		ChainId:   prefixedChainIDString(shared.ChainID),
 		Data:      balanceData,
 		EventType: EventTypeBalance,
-		Network:   networkName(shared.ChainID),
-		Protocol:  ProtocolEthereum,
+		Network:   "",
+		Protocol:  "",
 	}
 }
 
@@ -176,8 +167,8 @@ func (eventData *ActionEventData) ToTransactionLog() webhook.WebhookMessageUnifi
 			TxId:        txHash,
 		},
 		EventType: EventTypeTransactionLog,
-		Network:   networkName(shared.ChainID),
-		Protocol:  ProtocolEthereum,
+		Network:   "",
+		Protocol:  "",
 	}
 }
 
@@ -198,17 +189,9 @@ func (eventData *ActionEventData) toBalance(address *common.Address, balance *bi
 		ChainId:   prefixedChainIDString(shared.ChainID),
 		Data:      balanceData,
 		EventType: EventTypeBalance,
-		Network:   networkName(shared.ChainID),
-		Protocol:  ProtocolEthereum,
+		Network:   "",
+		Protocol:  "",
 	}
-}
-
-func networkName(chainID *big.Int) string {
-	name, ok := networkMap[chainID.String()]
-	if !ok {
-		return ""
-	}
-	return name
 }
 
 func prefixedChainIDString(chainID *big.Int) string {

--- a/main.go
+++ b/main.go
@@ -142,7 +142,6 @@ var realtimeBlocksCmd = &cobra.Command{
 			ctx,
 			&options.NATS,
 			actions.AddAddressToMonitoredAddresses,
-			actions.AddContractAddressToMonitoredAddresses,
 		); err != nil {
 			return fmt.Errorf("Failed to initialize NATS client: %w", err)
 		}
@@ -180,6 +179,16 @@ var historicalCmd = &cobra.Command{
 
 		actions.InitActions(options.Actions)
 
+		// Initialize NATS so wallets can be received during historical processing
+		ctx := cmd.Context()
+		if err := shared.InitNATS(
+			ctx,
+			&options.NATS,
+			actions.AddAddressToMonitoredAddresses,
+		); err != nil {
+			shared.Warnf(slog.Default(), "Failed to initialize NATS client for historical: %v", err)
+		}
+
 		if shared.BlockTrackingRequired {
 			trackooor.GetPastBlocks()
 		} else {
@@ -204,6 +213,16 @@ var historicalEventsCmd = &cobra.Command{
 
 		actions.InitActions(options.Actions)
 
+		// Initialize NATS so wallets can be received during historical processing
+		ctx := cmd.Context()
+		if err := shared.InitNATS(
+			ctx,
+			&options.NATS,
+			actions.AddAddressToMonitoredAddresses,
+		); err != nil {
+			shared.Warnf(slog.Default(), "Failed to initialize NATS client for historical events: %v", err)
+		}
+
 		trackooor.GetPastEventsSingle()
 	},
 }
@@ -223,6 +242,16 @@ var historicalBlocksCmd = &cobra.Command{
 		trackooor.SetupHistorical()
 
 		actions.InitActions(options.Actions)
+
+		// Initialize NATS so wallets can be received during historical blocks processing
+		ctx := cmd.Context()
+		if err := shared.InitNATS(
+			ctx,
+			&options.NATS,
+			actions.AddAddressToMonitoredAddresses,
+		); err != nil {
+			shared.Warnf(slog.Default(), "Failed to initialize NATS client for historical blocks: %v", err)
+		}
 
 		trackooor.GetPastBlocks()
 	},

--- a/shared/common.go
+++ b/shared/common.go
@@ -7,7 +7,9 @@ import (
 	"log"
 	"log/slog"
 	"math/big"
+	"net/http"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -144,11 +146,29 @@ func TimeLogger(whichController string) *log.Logger {
 
 func ConnectToRPC(rpcURL string) (*ethclient.Client, *big.Int) {
 	Infof(slog.Default(), "Connecting to RPC URL...\n")
-	// client, err := ethclient.Dial(rpcURL)
+	// Build dial options and include optional HTTP/WebSocket headers from env
+	var clientOptions []rpc.ClientOption
+	clientOptions = append(clientOptions, rpc.WithWebsocketMessageSizeLimit(0))
+
+	// Support explicit key/value envs first, fallback to legacy RPC_HEADER="Key:Value"
+	{
+		var hdr http.Header
+		if key, val := os.Getenv("RPC_HEADER_KEY"), os.Getenv("RPC_HEADER_VALUE"); key != "" && val != "" {
+			hdr = http.Header{}
+			hdr.Add(strings.TrimSpace(key), strings.TrimSpace(val))
+		}
+		if hdr != nil {
+			clientOptions = append(clientOptions, rpc.WithHeaders(hdr))
+			for k := range hdr {
+				Infof(slog.Default(), "Applied RPC header '%s' from environment\n", k)
+			}
+		}
+	}
+
 	RpcClient, err := rpc.DialOptions(
 		context.Background(),
 		rpcURL,
-		rpc.WithWebsocketMessageSizeLimit(0), // no limit
+		clientOptions...,
 	)
 	client := ethclient.NewClient(RpcClient)
 

--- a/shared/common.go
+++ b/shared/common.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 
+	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -36,8 +37,7 @@ var UseDualTransferWalletFilters bool
 // Pre-encoded wallet addresses as 32-byte topic hashes for filtering
 // (left-padded address bytes). Populated at runtime based on configured
 // monitored wallet addresses.
-var FilterWalletTopics []common.Hash
-var FilterWalletTopicsMutex sync.RWMutex
+var monitoredAddressHashes = mapset.NewSet[common.Hash]()
 
 // Channel to notify when a new wallet address is added for server-side
 // wallet-topic ERC20 Transfer subscriptions.
@@ -147,6 +147,11 @@ func init() {
 	ERC20TokenInfos = make(map[common.Address]ERC20Info)
 	AddressTypeCache = make(map[common.Address]int)
 	NewWalletTopicChan = make(chan common.Address, 1024)
+}
+
+// MonitoredAddressHashes returns the thread-safe set of monitored address hashes.
+func MonitoredAddressHashes() mapset.Set[common.Hash] {
+	return monitoredAddressHashes
 }
 
 func Infof(logger *slog.Logger, format string, args ...any) {

--- a/shared/common.go
+++ b/shared/common.go
@@ -37,6 +37,7 @@ var UseDualTransferWalletFilters bool
 // (left-padded address bytes). Populated at runtime based on configured
 // monitored wallet addresses.
 var FilterWalletTopics []common.Hash
+var FilterWalletTopicsMutex sync.RWMutex
 
 // Channel to notify when a new wallet address is added for server-side
 // wallet-topic ERC20 Transfer subscriptions.

--- a/shared/common.go
+++ b/shared/common.go
@@ -27,6 +27,21 @@ var RpcURL string
 var Verbose bool
 var Options TrackooorOptions
 
+// When enabled, event subscriptions will use dual topic filters to monitor any
+// ERC20 transfers where either the sender (topic1) or receiver (topic2)
+// matches one of the registered wallet addresses. This allows server-side
+// filtering by the node without specifying token contract addresses.
+var UseDualTransferWalletFilters bool
+
+// Pre-encoded wallet addresses as 32-byte topic hashes for filtering
+// (left-padded address bytes). Populated at runtime based on configured
+// monitored wallet addresses.
+var FilterWalletTopics []common.Hash
+
+// Channel to notify when a new wallet address is added for server-side
+// wallet-topic ERC20 Transfer subscriptions.
+var NewWalletTopicChan chan common.Address
+
 // JSON data
 var EventSigs map[string]interface{} // from data file, maps hex string to event abi
 var FuncSigs map[string]interface{}  // from data file, maps hex string (func selector) to func abi
@@ -130,6 +145,7 @@ func init() {
 	// init maps
 	ERC20TokenInfos = make(map[common.Address]ERC20Info)
 	AddressTypeCache = make(map[common.Address]int)
+	NewWalletTopicChan = make(chan common.Address, 1024)
 }
 
 func Infof(logger *slog.Logger, format string, args ...any) {

--- a/shared/nats.go
+++ b/shared/nats.go
@@ -265,8 +265,20 @@ func requestAddressList(ctx context.Context) error {
 		return errors.New("not connected to nats server")
 	}
 
+	// Prepare request payload including desired chain hints
+	type addressListQuery struct {
+		ChainID int64 `json:"chain_id,omitempty"`
+	}
+
+	query := addressListQuery{}
+	if ChainID != nil {
+		query.ChainID = ChainID.Int64()
+	}
+
+	payload, _ := json.Marshal(query)
+
 	// Send request with timeout context
-	msg, err := natsConn.RequestWithContext(ctx, SubjectAddressListRequest, nil)
+	msg, err := natsConn.RequestWithContext(ctx, SubjectAddressListRequest, payload)
 	if err != nil {
 		return fmt.Errorf("failed to send request to NATS: %w", err)
 	}
@@ -318,6 +330,13 @@ func subscribeToAddress() error {
 				slog.Error("handling contract address", "error", err)
 				return
 			}
+
+			slog.Info(
+				"Monitored address registered",
+				"protocol", address.Protocol,
+				"network", address.Network,
+				"address", address.Address,
+			)
 		},
 	)
 	if err != nil {

--- a/shared/nats.go
+++ b/shared/nats.go
@@ -278,7 +278,7 @@ func requestAddressList(ctx context.Context) error {
 
 	// Backoff-and-retry when there are no responders
 	const (
-		maxAttempts      = 5
+		maxAttempts      = 10
 		initialBackoffMs = 500
 	)
 	backoff := time.Duration(initialBackoffMs) * time.Millisecond

--- a/shared/nats.go
+++ b/shared/nats.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -20,12 +21,12 @@ const (
 )
 
 var (
-	natsConn                               *nats.Conn
-	natsMutex                              sync.RWMutex
-	natsOptions                            *NATSOptions
-	subscription                           *nats.Subscription
-	addressHandler, contractAddressHandler AddressHandler
-	stopLoggingFunc                        func()
+	natsConn        *nats.Conn
+	natsMutex       sync.RWMutex
+	natsOptions     *NATSOptions
+	subscription    *nats.Subscription
+	addressHandler  AddressHandler
+	stopLoggingFunc func()
 )
 
 type (
@@ -68,7 +69,7 @@ func CloseNATS() error {
 func InitNATS(
 	ctx context.Context,
 	options *NATSOptions,
-	addressHandlerInput, contractAddressHandlerInput AddressHandler,
+	addressHandlerInput AddressHandler,
 ) error {
 	natsMutex.Lock()
 	defer natsMutex.Unlock()
@@ -85,11 +86,6 @@ func InitNATS(
 		return errors.New("address handler already set")
 	}
 	addressHandler = addressHandlerInput
-
-	if contractAddressHandler != nil {
-		return errors.New("contract address handler already set")
-	}
-	contractAddressHandler = contractAddressHandlerInput
 
 	natsOptions = options
 
@@ -125,6 +121,9 @@ func PublishSerializable(data any) error {
 	if err := natsConn.Flush(); err != nil {
 		return fmt.Errorf("failed to flush NATS connection: %w", err)
 	}
+
+	// Log publish event
+	slog.Info("Published to NATS", "subject", SubjectTransfer, "bytes", len(jsonData))
 
 	return nil
 }
@@ -277,31 +276,52 @@ func requestAddressList(ctx context.Context) error {
 
 	payload, _ := json.Marshal(query)
 
-	// Send request with timeout context
-	msg, err := natsConn.RequestWithContext(ctx, SubjectAddressListRequest, payload)
-	if err != nil {
+	// Backoff-and-retry when there are no responders
+	const (
+		maxAttempts      = 5
+		initialBackoffMs = 500
+	)
+	backoff := time.Duration(initialBackoffMs) * time.Millisecond
+	var lastErr error
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		// Send request with timeout context
+		msg, err := natsConn.RequestWithContext(ctx, SubjectAddressListRequest, payload)
+		if err == nil {
+			// Process the response
+			var addresses []AddressIdentifier
+			if unmarshalErr := json.Unmarshal(msg.Data, &addresses); unmarshalErr != nil {
+				return fmt.Errorf("failed to unmarshal addresses: %w", unmarshalErr)
+			}
+
+			slog.Info("Received addresses from NATS", "addresses", addresses)
+
+			for _, address := range addresses {
+				if handleErr := addressHandler(common.HexToAddress(address.Address)); handleErr != nil {
+					return fmt.Errorf("failed to add address to monitored addresses: %w", handleErr)
+				}
+			}
+			return nil
+		}
+
+		lastErr = err
+		// Retry only on no responders, otherwise return immediately
+		if errors.Is(err, nats.ErrNoResponders) || (err != nil && strings.Contains(err.Error(), "no responders")) {
+			slog.Warn("No NATS responders, backing off", "attempt", attempt, "max", maxAttempts, "backoff", backoff)
+			// Wait with context awareness
+			select {
+			case <-time.After(backoff):
+				backoff *= 2
+				continue
+			case <-ctx.Done():
+				return fmt.Errorf("context cancelled while waiting to retry NATS request: %w", ctx.Err())
+			}
+		}
+
 		return fmt.Errorf("failed to send request to NATS: %w", err)
 	}
 
-	// Process the response
-	var addresses []AddressIdentifier
-	if err := json.Unmarshal(msg.Data, &addresses); err != nil {
-		return fmt.Errorf("failed to unmarshal addresses: %w", err)
-	}
-
-	slog.Info("Received addresses from NATS", "addresses", addresses)
-
-	for _, address := range addresses {
-		if err := addressHandler(common.HexToAddress(address.Address)); err != nil {
-			return fmt.Errorf("failed to add address to monitored addresses: %w", err)
-		}
-
-		if err := contractAddressHandler(common.HexToAddress(address.Address)); err != nil {
-			return fmt.Errorf("failed to add contract address to monitored addresses: %w", err)
-		}
-	}
-
-	return nil
+	return fmt.Errorf("failed to send request to NATS after retries: %w", lastErr)
 }
 
 // subscribeToAddress subscribes to address addition and adds it to the monitored addresses.
@@ -323,11 +343,6 @@ func subscribeToAddress() error {
 
 			if err := addressHandler(common.HexToAddress(address.Address)); err != nil {
 				slog.Error("handling address", "error", err)
-				return
-			}
-
-			if err := contractAddressHandler(common.HexToAddress(address.Address)); err != nil {
-				slog.Error("handling contract address", "error", err)
 				return
 			}
 

--- a/shared/nats.go
+++ b/shared/nats.go
@@ -341,6 +341,9 @@ func subscribeToAddress() error {
 				return
 			}
 
+			// Always print to console when a wallet address is published via NATS
+			fmt.Printf("Published wallet address received: %s (protocol=%s, network=%s)\n", address.Address, address.Protocol, address.Network)
+
 			if err := addressHandler(common.HexToAddress(address.Address)); err != nil {
 				slog.Error("handling address", "error", err)
 				return

--- a/shared/nats_suite_test.go
+++ b/shared/nats_suite_test.go
@@ -70,7 +70,6 @@ func (s *NATSSuite) TestInitNATS_Error() {
 		s.Suite.T().Context(),
 		&NATSOptions{URL: s.natsServerURL},
 		addressHandler,
-		addressHandler,
 	)
 	s.Require().Error(err)
 	s.Require().Contains(err.Error(), "failed to add address to monitored addresses")
@@ -339,18 +338,10 @@ func (s *NATSSuite) initNATSWithHandlers(addresses []AddressIdentifier) {
 		return nil
 	}
 
-	contractAddressHandler := func(address common.Address) error {
-		s.lock.Lock()
-		defer s.lock.Unlock()
-		s.contractAddresses = append(s.contractAddresses, address)
-		return nil
-	}
-
 	err := InitNATS(
 		s.Suite.T().Context(),
 		options,
 		addressHandler,
-		contractAddressHandler,
 	)
 	s.Require().NoError(err)
 
@@ -378,7 +369,6 @@ func (s *NATSSuite) resetPackageVariables() {
 
 	natsOptions = nil
 	addressHandler = nil
-	contractAddressHandler = nil
 }
 
 // setupAddressListResponder sets up a NATS subscription to respond to address list requests with the given addresses

--- a/trackooor/blocklistener.go
+++ b/trackooor/blocklistener.go
@@ -14,23 +14,67 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/schollz/progressbar/v3"
 )
 
 // handles all events emitted in a given block,
 func handleEventsFromBlock(block *types.Block, contracts []common.Address) {
-	// blockHash := block.Hash()
-	query := ethereum.FilterQuery{
-		// BlockHash: &blockHash,
-		FromBlock: block.Number(),
-		ToBlock:   block.Number(),
-		Addresses: contracts,
-		Topics:    shared.Options.FilterEventTopics,
+	// Only wallet-topic filtering when enabled; otherwise fallback to default query
+	var logs []types.Log
+	if !(shared.UseDualTransferWalletFilters && len(shared.FilterWalletTopics) > 0) {
+		query := ethereum.FilterQuery{
+			// BlockHash: &blockHash,
+			FromBlock: block.Number(),
+			ToBlock:   block.Number(),
+			Addresses: contracts,
+			Topics:    shared.Options.FilterEventTopics,
+		}
+		queriedLogs, err := shared.Client.FilterLogs(context.Background(), query)
+		if err != nil {
+			log.Fatal(err)
+		}
+		logs = append(logs, queriedLogs...)
 	}
-	logs, err := shared.Client.FilterLogs(context.Background(), query)
-	if err != nil {
-		log.Fatal(err)
+
+	// If configured, also query ERC20 Transfer events filtered by wallet topics
+	if shared.UseDualTransferWalletFilters && len(shared.FilterWalletTopics) > 0 {
+		// ToDo: Watch contract functions other than Transfer
+		transferTopic0 := []common.Hash{crypto.Keccak256Hash([]byte("Transfer(address,address,uint256)"))}
+
+		fromQuery := ethereum.FilterQuery{
+			FromBlock: block.Number(),
+			ToBlock:   block.Number(),
+			Topics: [][]common.Hash{
+				transferTopic0,            // topic0 = Transfer
+				shared.FilterWalletTopics, // topic1 = from wallets
+			},
+		}
+		if shared.Verbose {
+			slog.Info("Block ERC20 FROM filter", "block", block.Number(), "topics", fromQuery.Topics)
+		}
+		fromLogs, err := shared.Client.FilterLogs(context.Background(), fromQuery)
+		if err == nil {
+			logs = append(logs, fromLogs...)
+		}
+
+		toQuery := ethereum.FilterQuery{
+			FromBlock: block.Number(),
+			ToBlock:   block.Number(),
+			Topics: [][]common.Hash{
+				transferTopic0,            // topic0 = Transfer
+				nil,                       // topic1 = any
+				shared.FilterWalletTopics, // topic2 = to wallets
+			},
+		}
+		if shared.Verbose {
+			slog.Info("Block ERC20 TO filter", "block", block.Number(), "topics", toQuery.Topics)
+		}
+		toLogs, err := shared.Client.FilterLogs(context.Background(), toQuery)
+		if err == nil {
+			logs = append(logs, toLogs...)
+		}
 	}
 
 	var bar *progressbar.ProgressBar

--- a/trackooor/blocklistener.go
+++ b/trackooor/blocklistener.go
@@ -23,7 +23,15 @@ import (
 func handleEventsFromBlock(block *types.Block, contracts []common.Address) {
 	// Only wallet-topic filtering when enabled; otherwise fallback to default query
 	var logs []types.Log
-	if !(shared.UseDualTransferWalletFilters && len(shared.FilterWalletTopics) > 0) {
+
+	// Make a copy of FilterWalletTopics to avoid holding the lock during network calls
+	shared.FilterWalletTopicsMutex.RLock()
+	walletTopicsCopy := make([]common.Hash, len(shared.FilterWalletTopics))
+	copy(walletTopicsCopy, shared.FilterWalletTopics)
+	hasWalletTopics := len(shared.FilterWalletTopics) > 0
+	shared.FilterWalletTopicsMutex.RUnlock()
+
+	if !(shared.UseDualTransferWalletFilters && hasWalletTopics) {
 		query := ethereum.FilterQuery{
 			// BlockHash: &blockHash,
 			FromBlock: block.Number(),
@@ -39,7 +47,7 @@ func handleEventsFromBlock(block *types.Block, contracts []common.Address) {
 	}
 
 	// If configured, also query ERC20 Transfer events filtered by wallet topics
-	if shared.UseDualTransferWalletFilters && len(shared.FilterWalletTopics) > 0 {
+	if shared.UseDualTransferWalletFilters && hasWalletTopics {
 		// ToDo: Watch contract functions other than Transfer
 		transferTopic0 := []common.Hash{crypto.Keccak256Hash([]byte("Transfer(address,address,uint256)"))}
 
@@ -47,8 +55,8 @@ func handleEventsFromBlock(block *types.Block, contracts []common.Address) {
 			FromBlock: block.Number(),
 			ToBlock:   block.Number(),
 			Topics: [][]common.Hash{
-				transferTopic0,            // topic0 = Transfer
-				shared.FilterWalletTopics, // topic1 = from wallets
+				transferTopic0,   // topic0 = Transfer
+				walletTopicsCopy, // topic1 = from wallets
 			},
 		}
 		if shared.Verbose {
@@ -63,9 +71,9 @@ func handleEventsFromBlock(block *types.Block, contracts []common.Address) {
 			FromBlock: block.Number(),
 			ToBlock:   block.Number(),
 			Topics: [][]common.Hash{
-				transferTopic0,            // topic0 = Transfer
-				nil,                       // topic1 = any
-				shared.FilterWalletTopics, // topic2 = to wallets
+				transferTopic0,   // topic0 = Transfer
+				nil,              // topic1 = any
+				walletTopicsCopy, // topic2 = to wallets
 			},
 		}
 		if shared.Verbose {

--- a/trackooor/blocklistener.go
+++ b/trackooor/blocklistener.go
@@ -23,12 +23,9 @@ import (
 func handleEventsFromBlock(block *types.Block, contracts []common.Address) {
 	var logs []types.Log
 
-	// Make a copy of FilterWalletTopics to avoid holding the lock during network calls
-	shared.FilterWalletTopicsMutex.RLock()
-	walletTopicsCopy := make([]common.Hash, len(shared.FilterWalletTopics))
-	copy(walletTopicsCopy, shared.FilterWalletTopics)
-	hasWalletTopics := len(shared.FilterWalletTopics) > 0
-	shared.FilterWalletTopicsMutex.RUnlock()
+	// Get a snapshot of monitored address hashes to avoid lock contention during network calls
+	walletTopicsCopy := shared.MonitoredAddressHashes().ToSlice()
+	hasWalletTopics := len(walletTopicsCopy) > 0
 
 	// Use wallet-topic filtering when enabled, otherwise fallback to contract-based filtering
 	if shared.UseDualTransferWalletFilters && hasWalletTopics {

--- a/trackooor/blocklistener.go
+++ b/trackooor/blocklistener.go
@@ -21,7 +21,6 @@ import (
 
 // handles all events emitted in a given block,
 func handleEventsFromBlock(block *types.Block, contracts []common.Address) {
-	// Only wallet-topic filtering when enabled; otherwise fallback to default query
 	var logs []types.Log
 
 	// Make a copy of FilterWalletTopics to avoid holding the lock during network calls
@@ -31,26 +30,18 @@ func handleEventsFromBlock(block *types.Block, contracts []common.Address) {
 	hasWalletTopics := len(shared.FilterWalletTopics) > 0
 	shared.FilterWalletTopicsMutex.RUnlock()
 
-	if !(shared.UseDualTransferWalletFilters && hasWalletTopics) {
-		query := ethereum.FilterQuery{
-			// BlockHash: &blockHash,
-			FromBlock: block.Number(),
-			ToBlock:   block.Number(),
-			Addresses: contracts,
-			Topics:    shared.Options.FilterEventTopics,
-		}
-		queriedLogs, err := shared.Client.FilterLogs(context.Background(), query)
-		if err != nil {
-			log.Fatal(err)
-		}
-		logs = append(logs, queriedLogs...)
-	}
-
-	// If configured, also query ERC20 Transfer events filtered by wallet topics
+	// Use wallet-topic filtering when enabled, otherwise fallback to contract-based filtering
 	if shared.UseDualTransferWalletFilters && hasWalletTopics {
-		// ToDo: Watch contract functions other than Transfer
-		transferTopic0 := []common.Hash{crypto.Keccak256Hash([]byte("Transfer(address,address,uint256)"))}
+		// Monitor by wallet addresses using ERC20 Transfer event topic filtering
+		// This allows server-side filtering without specifying token contract addresses
 
+		// Determine the Keccak-256 hash of the event signature.
+		// This will be the first topic in our filter query.
+		eventSignature := "Transfer(address,address,uint256)"
+		topic0 := crypto.Keccak256Hash([]byte(eventSignature))
+		transferTopic0 := []common.Hash{topic0}
+
+		// Query for transfers FROM monitored wallets
 		fromQuery := ethereum.FilterQuery{
 			FromBlock: block.Number(),
 			ToBlock:   block.Number(),
@@ -67,6 +58,7 @@ func handleEventsFromBlock(block *types.Block, contracts []common.Address) {
 			logs = append(logs, fromLogs...)
 		}
 
+		// Query for transfers TO monitored wallets
 		toQuery := ethereum.FilterQuery{
 			FromBlock: block.Number(),
 			ToBlock:   block.Number(),
@@ -83,6 +75,19 @@ func handleEventsFromBlock(block *types.Block, contracts []common.Address) {
 		if err == nil {
 			logs = append(logs, toLogs...)
 		}
+	} else {
+		// Fallback: Monitor by contract addresses
+		query := ethereum.FilterQuery{
+			FromBlock: block.Number(),
+			ToBlock:   block.Number(),
+			Addresses: contracts,
+			Topics:    shared.Options.FilterEventTopics,
+		}
+		queriedLogs, err := shared.Client.FilterLogs(context.Background(), query)
+		if err != nil {
+			log.Fatal(err)
+		}
+		logs = append(logs, queriedLogs...)
 	}
 
 	var bar *progressbar.ProgressBar


### PR DESCRIPTION
- Replaces IV Protocol and Network enums with ChainID obtained from RPC method (IV does lookup against blockchain config to determine Protocol and Network  from ChainID)
- Monitors for ANY contract Transfer() event where either the To or From address matches an IV wallet address (uses RPC server-side filters)
- No longer retrieves contract addresses from IV (since its watches for any token contract related to IV addresses)
- Backoff & retry when NATS Addresses response is unavailable